### PR TITLE
Update after LibreCube RafUser interface change

### DIFF
--- a/docs/QuickStartGuideLibreCube.md
+++ b/docs/QuickStartGuideLibreCube.md
@@ -48,7 +48,7 @@ import sle
 
 raf_service = sle.RafUser(
     service_instance_identifier="sagr=1.spack=VST-PASS0001.rsl-fg=1.raf=onlt1",
-    responder_ip="localhost",
+    responder_host="localhost",
     responder_port=55529,
     auth_level=None,
     local_identifier="SLE_USER",


### PR DESCRIPTION
The LibreCube RAFUser responder_ip parameter name changed to responder_host, this was now updated in the QuickStartGuide